### PR TITLE
Fix: Trams becoming stuck after reset

### DIFF
--- a/pkg/city/city.go
+++ b/pkg/city/city.go
@@ -71,3 +71,9 @@ func (c *City) GetRoutesForStop(stopID uint64, chipPerRowSize int) []RouteInfo {
 	}
 	return processedRoutes
 }
+
+func (c *City) UnblockGraph() {
+	for _, node := range c.nodesByID {
+		node.Unblock(0)
+	}
+}

--- a/pkg/simulation/simulation.go
+++ b/pkg/simulation/simulation.go
@@ -35,10 +35,6 @@ func (s *Simulation) tramWorker() {
 }
 
 func (s *Simulation) resetTrams() {
-	for _, tram := range s.trams {
-		tram.unblockWholePath()
-	}
-
 	s.trams = make(map[uint]*tram)
 	for _, route := range s.city.GetTramRoutes() {
 		for _, trip := range route.Trips {
@@ -48,6 +44,7 @@ func (s *Simulation) resetTrams() {
 }
 
 func (s *Simulation) ResetSimulation() {
+	s.city.UnblockGraph()
 	s.resetTrams()
 	s.city.ResetPlannedArrivals()
 }

--- a/pkg/simulation/tram.go
+++ b/pkg/simulation/tram.go
@@ -150,18 +150,6 @@ func (t *tram) unblockNodesBehind() {
 	}
 }
 
-func (t *tram) unblockWholePath() {
-	t.unblockNodesBehind()
-	if t.state != StateTravelling {
-		return
-	}
-
-	path := t.getTravelPath()
-	for _, node := range path.Nodes {
-		node.Unblock(t.id)
-	}
-}
-
 func (t *tram) getEstimatedArrival(stopIndex int, time uint) uint {
 	if t.tripData.index > stopIndex || t.tripData.index == stopIndex && t.isAtStop() {
 		return t.tripData.arrivals[stopIndex]

--- a/pkg/simulation/tram.go
+++ b/pkg/simulation/tram.go
@@ -156,11 +156,7 @@ func (t *tram) unblockWholePath() {
 		return
 	}
 
-	path := t.controlCenter.GetPath(
-		t.tripData.trip.Stops[t.tripData.index].ID,
-		t.tripData.trip.Stops[t.tripData.index+1].ID,
-	)
-
+	path := t.getTravelPath()
 	for _, node := range path.Nodes {
 		node.Unblock(t.id)
 	}
@@ -381,7 +377,6 @@ func (t *tram) updateSpeedAndReserveNodes(path []*city.GraphNode) (availableDist
 }
 
 func (t *tram) onTravelling(time uint) (result TramPositionChange, update bool) {
-
 	path := t.getTravelPath()
 
 	if t.distToNextInterNode == 0 {


### PR DESCRIPTION
### Related issues
- #25 

### Short description
Fix the `unblockWholePath()` method so it processes the current path of the tram instead of the following one.
