### PR TITLE
route sidebar functionality

### DIFF
--- a/frontend/src/classes/LeafletMap.ts
+++ b/frontend/src/classes/LeafletMap.ts
@@ -1,15 +1,9 @@
 import { GetBounds, GetTramStops } from "@wails/go/city/City"
-import { GetRoutePolylines } from "@wails/go/simulation/Simulation"
-import L, {
-  LatLngBounds,
-  Map as LMap,
-  tileLayer,
-  FeatureGroup,
-  Polyline,
-} from "leaflet"
+import { LatLngBounds, Map as LMap, tileLayer } from "leaflet"
 import { TramMarker } from "@classes/TramMarker"
 import { StopMarker } from "@classes/StopMarker"
 import { city, simulation } from "@wails/go/models"
+import { RouteHighlighter } from "./RouteHighlighter"
 
 export class LeafletMap {
   private entityCount = 0
@@ -17,12 +11,10 @@ export class LeafletMap {
   public selectedTram?: TramMarker
   public selectedRouteName?: string
   public highlightedRouteTrams?: TramMarker[]
-  private routeLayer: FeatureGroup | null = null
-  private svgRenderer = L.svg()
-  private antsAnims: Animation[] = []
+  private routeHighlighter: RouteHighlighter
 
   constructor(private map: LMap) {
-    this.map.addLayer(this.svgRenderer)
+    this.routeHighlighter = new RouteHighlighter(map)
   }
 
   static async init(
@@ -69,31 +61,6 @@ export class LeafletMap {
     return leafletMap
   }
 
-  private stopAnts() {
-    this.antsAnims.forEach(a => a.cancel())
-    this.antsAnims = []
-  }
-
-  private animateAlongPath(el: SVGPathElement, periodMs = 1100, dashSum = 22) {
-    el.style.strokeDasharray = "12 10"
-    const anim = el.animate(
-      [{ strokeDashoffset: "0" }, { strokeDashoffset: String(-dashSum) }],
-      { duration: periodMs, iterations: Infinity, easing: "linear" },
-    )
-    this.antsAnims.push(anim)
-  }
-
-  private makePolyline(coords: [number, number][], color: string) {
-    return new Polyline(coords, {
-      weight: 5,
-      opacity: 1,
-      smoothFactor: 3,
-      color: color,
-      renderer: this.svgRenderer,
-      interactive: false,
-    })
-  }
-
   public highlightTramsForRoute(trams: TramMarker[]) {
     this.highlightedRouteTrams?.forEach(m => m.setHighlighted(false))
     this.highlightedRouteTrams = trams
@@ -102,38 +69,14 @@ export class LeafletMap {
 
   public async highlightRoute(route: city.RouteInfo) {
     this.selectedRouteName = route.name
-    const { forward, backward } = await GetRoutePolylines(route.name)
-
-    const fwd = forward as [number, number][]
-    const bwd = backward as [number, number][]
-
-    if (this.routeLayer) {
-      this.map.removeLayer(this.routeLayer)
-      this.routeLayer = null
-    }
-
-    const layers: Polyline[] = [
-      this.makePolyline(fwd, route.background_color),
-      this.makePolyline(bwd, route.background_color),
-    ]
-
-    this.routeLayer = new FeatureGroup(layers).addTo(this.map)
-    this.stopAnts()
-    for (const l of layers) {
-      const el = l.getElement() as SVGPathElement | null
-      if (el) this.animateAlongPath(el, 1100, 22)
-    }
+    await this.routeHighlighter.highlight(route)
   }
 
   public deselectRoute() {
-    this.stopAnts()
-    if (this.routeLayer) {
-      this.map.removeLayer(this.routeLayer)
-      this.routeLayer = null
-      this.selectedRouteName = undefined
-      this.highlightedRouteTrams?.forEach(m => m.setHighlighted(false))
-      this.highlightedRouteTrams = undefined
-    }
+    this.selectedRouteName = undefined
+    this.highlightedRouteTrams?.forEach(m => m.setHighlighted(false))
+    this.highlightedRouteTrams = undefined
+    this.routeHighlighter.clear()
   }
 
   public deselectStop() {

--- a/frontend/src/classes/LeafletMap.ts
+++ b/frontend/src/classes/LeafletMap.ts
@@ -1,5 +1,12 @@
 import { GetBounds, GetTramStops } from "@wails/go/city/City"
-import { LatLngBounds, Map as LMap, tileLayer } from "leaflet"
+import { GetRoutePolylines } from "@wails/go/simulation/Simulation"
+import L, {
+  LatLngBounds,
+  Map as LMap,
+  tileLayer,
+  FeatureGroup,
+  Polyline,
+} from "leaflet"
 import { TramMarker } from "@classes/TramMarker"
 import { StopMarker } from "@classes/StopMarker"
 import { city, simulation } from "@wails/go/models"
@@ -8,8 +15,15 @@ export class LeafletMap {
   private entityCount = 0
   public selectedStop?: StopMarker
   public selectedTram?: TramMarker
+  public selectedRouteName?: string
+  public highlightedRouteTrams?: TramMarker[]
+  private routeLayer: FeatureGroup | null = null
+  private svgRenderer = L.svg()
+  private antsAnims: Animation[] = []
 
-  constructor(private map: LMap) {}
+  constructor(private map: LMap) {
+    this.map.addLayer(this.svgRenderer)
+  }
 
   static async init(
     mapHTMLElement: HTMLElement,
@@ -53,6 +67,73 @@ export class LeafletMap {
     }).addTo(leafletMap.map)
 
     return leafletMap
+  }
+
+  private stopAnts() {
+    this.antsAnims.forEach(a => a.cancel())
+    this.antsAnims = []
+  }
+
+  private animateAlongPath(el: SVGPathElement, periodMs = 1100, dashSum = 22) {
+    el.style.strokeDasharray = "12 10"
+    const anim = el.animate(
+      [{ strokeDashoffset: "0" }, { strokeDashoffset: String(-dashSum) }],
+      { duration: periodMs, iterations: Infinity, easing: "linear" },
+    )
+    this.antsAnims.push(anim)
+  }
+
+  private makePolyline(coords: [number, number][], color: string) {
+    return new Polyline(coords, {
+      weight: 5,
+      opacity: 1,
+      smoothFactor: 3,
+      color: color,
+      renderer: this.svgRenderer,
+      interactive: false,
+    })
+  }
+
+  public highlightTramsForRoute(trams: TramMarker[]) {
+    this.highlightedRouteTrams?.forEach(m => m.setHighlighted(false))
+    this.highlightedRouteTrams = trams
+    this.highlightedRouteTrams.forEach(m => m.setHighlighted(true))
+  }
+
+  public async highlightRoute(route: city.RouteInfo) {
+    this.selectedRouteName = route.name
+    const { forward, backward } = await GetRoutePolylines(route.name)
+
+    const fwd = forward as [number, number][]
+    const bwd = backward as [number, number][]
+
+    if (this.routeLayer) {
+      this.map.removeLayer(this.routeLayer)
+      this.routeLayer = null
+    }
+
+    const layers: Polyline[] = [
+      this.makePolyline(fwd, route.background_color),
+      this.makePolyline(bwd, route.background_color),
+    ]
+
+    this.routeLayer = new FeatureGroup(layers).addTo(this.map)
+    this.stopAnts()
+    for (const l of layers) {
+      const el = l.getElement() as SVGPathElement | null
+      if (el) this.animateAlongPath(el, 1100, 22)
+    }
+  }
+
+  public deselectRoute() {
+    this.stopAnts()
+    if (this.routeLayer) {
+      this.map.removeLayer(this.routeLayer)
+      this.routeLayer = null
+      this.selectedRouteName = undefined
+      this.highlightedRouteTrams?.forEach(m => m.setHighlighted(false))
+      this.highlightedRouteTrams = undefined
+    }
   }
 
   public deselectStop() {

--- a/frontend/src/classes/RouteHighlighter.ts
+++ b/frontend/src/classes/RouteHighlighter.ts
@@ -11,7 +11,7 @@ export class RouteHighlighter {
     this.map.addLayer(this.svgRenderer)
   }
 
-  async highlight(route: city.RouteInfo) {
+  public async highlight(route: city.RouteInfo) {
     const { forward, backward } = await GetRoutePolylines(route.name)
     const fwd = forward as [number, number][]
     const bwd = backward as [number, number][]
@@ -33,7 +33,7 @@ export class RouteHighlighter {
     }
   }
 
-  clear() {
+  public clear() {
     this.stopAnts()
     if (this.routeLayer) {
       this.map.removeLayer(this.routeLayer)

--- a/frontend/src/classes/RouteHighlighter.ts
+++ b/frontend/src/classes/RouteHighlighter.ts
@@ -1,0 +1,68 @@
+import L, { FeatureGroup, Polyline, Map as LMap } from "leaflet"
+import { GetRoutePolylines } from "@wails/go/simulation/Simulation"
+import { city } from "@wails/go/models"
+
+export class RouteHighlighter {
+  private routeLayer: FeatureGroup | null = null
+  private antsAnims: Animation[] = []
+  private svgRenderer = L.svg()
+
+  constructor(private map: LMap) {
+    this.map.addLayer(this.svgRenderer)
+  }
+
+  async highlight(route: city.RouteInfo) {
+    const { forward, backward } = await GetRoutePolylines(route.name)
+    const fwd = forward as [number, number][]
+    const bwd = backward as [number, number][]
+
+    if (this.routeLayer) {
+      this.map.removeLayer(this.routeLayer)
+    }
+
+    const layers: Polyline[] = [
+      this.makePolyline(fwd, route.background_color),
+      this.makePolyline(bwd, route.background_color),
+    ]
+
+    this.routeLayer = new FeatureGroup(layers).addTo(this.map)
+    this.stopAnts()
+    for (const l of layers) {
+      const el = l.getElement() as SVGPathElement | null
+      if (el) this.animateAlongPath(el, 1100, 22)
+    }
+  }
+
+  clear() {
+    this.stopAnts()
+    if (this.routeLayer) {
+      this.map.removeLayer(this.routeLayer)
+      this.routeLayer = null
+    }
+  }
+
+  private makePolyline(coords: [number, number][], color: string) {
+    return new Polyline(coords, {
+      weight: 5,
+      opacity: 1,
+      smoothFactor: 3,
+      color,
+      renderer: this.svgRenderer,
+      interactive: false,
+    })
+  }
+
+  private animateAlongPath(el: SVGPathElement, periodMs = 1100, dashSum = 22) {
+    el.style.strokeDasharray = "12 10"
+    const anim = el.animate(
+      [{ strokeDashoffset: "0" }, { strokeDashoffset: String(-dashSum) }],
+      { duration: periodMs, iterations: Infinity, easing: "linear" },
+    )
+    this.antsAnims.push(anim)
+  }
+
+  private stopAnts() {
+    this.antsAnims.forEach(a => a.cancel())
+    this.antsAnims = []
+  }
+}

--- a/frontend/src/classes/TramMarker.ts
+++ b/frontend/src/classes/TramMarker.ts
@@ -79,9 +79,7 @@ export class TramMarker extends Marker {
       this.leafletMap.addTram(this)
       this.isOnMap = true
     }
-    this.route === this.leafletMap.selectedRouteName
-      ? this.setHighlighted(true)
-      : this.setHighlighted(false)
+    this.setHighlighted(this.route === this.leafletMap.selectedRouteName)
     this.setLatLng([lat, lon])
     this.setAzimuth(azimuth)
   }

--- a/frontend/src/classes/TramMarker.ts
+++ b/frontend/src/classes/TramMarker.ts
@@ -3,13 +3,12 @@ import { LeafletMap } from "@classes/LeafletMap"
 
 export class TramMarker extends Marker {
   private isOnMap = false
-  private route: string
+
   constructor(
     private leafletMap: LeafletMap,
-    route: string,
+    private route: string,
   ) {
     super([0, 0], { icon: TramMarker.createIcon(route) })
-    this.route = route
   }
 
   private static createIcon(route: string): DivIcon {

--- a/frontend/src/classes/TramMarker.ts
+++ b/frontend/src/classes/TramMarker.ts
@@ -3,12 +3,13 @@ import { LeafletMap } from "@classes/LeafletMap"
 
 export class TramMarker extends Marker {
   private isOnMap = false
-
+  private route: string
   constructor(
     private leafletMap: LeafletMap,
     route: string,
   ) {
     super([0, 0], { icon: TramMarker.createIcon(route) })
+    this.route = route
   }
 
   private static createIcon(route: string): DivIcon {
@@ -36,6 +37,27 @@ export class TramMarker extends Marker {
     circleArrow.style.transform = `rotate(${azimuth + 135}deg)`
   }
 
+  public getRoute(): string {
+    return this.route
+  }
+
+  public getIsOnMap(): boolean {
+    return this.isOnMap
+  }
+
+  public setHighlighted(isHighlighted: boolean) {
+    const element =
+      this.getElement()?.querySelector<HTMLElement>(".tram-marker")
+    if (!element) {
+      return
+    }
+    if (isHighlighted) {
+      element?.classList.add("highlighted")
+    } else {
+      element?.classList.remove("highlighted")
+    }
+  }
+
   public setSelected(isSelected: boolean) {
     if (!this.isOnMap) return
 
@@ -58,7 +80,9 @@ export class TramMarker extends Marker {
       this.leafletMap.addTram(this)
       this.isOnMap = true
     }
-
+    this.route === this.leafletMap.selectedRouteName
+      ? this.setHighlighted(true)
+      : this.setHighlighted(false)
     this.setLatLng([lat, lon])
     this.setAzimuth(azimuth)
   }

--- a/frontend/src/components/sidebar/RouteSidebarComponent.vue
+++ b/frontend/src/components/sidebar/RouteSidebarComponent.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import SidebarComponent from "@components/sidebar/SidebarComponent.vue"
+import { ref, computed, watch } from "vue"
+import { city } from "@wails/go/models"
+import { TramMarker } from "@classes/TramMarker"
+const model = defineModel<boolean>({ required: true })
+
+const props = defineProps<{
+  route?: city.RouteInfo
+  tramMarkers: Record<number, TramMarker>
+}>()
+
+const tab = ref<"basic" | "occ" | "stops">("basic")
+
+const tramsInService = computed(() => {
+  if (!props.route?.name) return 0
+  return Object.values(props.tramMarkers).filter(
+    tram => tram.getRoute() === props.route!.name && tram.getIsOnMap(),
+  ).length
+})
+</script>
+
+<template>
+  <SidebarComponent
+    v-model="model"
+    position="right"
+    :title="'Route ' + (route?.name ?? 'Unknown route')"
+    title-icon="mdi-transit-connection-horizontal"
+  >
+    <div class="section">
+      <div class="label">
+        <v-icon icon="mdi-numeric" class="mr-2"></v-icon>
+        Trams in service
+      </div>
+
+      <div class="value">
+        {{ tramsInService?.valueOf() || 0 }}
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="label">
+        <v-icon icon="mdi-counter" class="mr-2"></v-icon>
+        Passengers on route
+      </div>
+
+      <div class="value">
+        <span> TODO </span>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="label">
+        <v-icon icon="mdi-wrench-check" class="mr-2"></v-icon>
+        Route status
+      </div>
+
+      <div class="value">
+        <span> TODO </span>
+      </div>
+    </div>
+    <v-tabs v-model="tab" grow>
+      <v-tab value="basic">Basic information</v-tab>
+      <v-tab value="occ">Occupancy graph</v-tab>
+      <v-tab value="stops">Stops list</v-tab>
+    </v-tabs>
+
+    <v-card-text>
+      <v-tabs-window v-model="tab">
+        <v-tabs-window-item value="basic">
+          Basic information TODO
+        </v-tabs-window-item>
+
+        <v-tabs-window-item value="occ">
+          Occupancy graph TODO
+        </v-tabs-window-item>
+
+        <v-tabs-window-item value="stops"> Stops list TODO </v-tabs-window-item>
+      </v-tabs-window>
+    </v-card-text>
+  </SidebarComponent>
+</template>

--- a/frontend/src/components/sidebar/SidebarComponent.vue
+++ b/frontend/src/components/sidebar/SidebarComponent.vue
@@ -2,27 +2,18 @@
 import { computed } from "vue"
 
 const model = defineModel({ required: true })
-
 const props = defineProps<{
   position: "left" | "right"
   titleIcon: string
   title: string
 }>()
 
-const horizontalPosition = computed(() => {
-  if (props.position == "left") {
-    return { left: "54px" }
-  } else {
-    return { right: "20px" }
-  }
-})
-
 const slideDirection = computed(() => `sidebar-slide-${props.position}`)
 </script>
 
 <template>
   <transition :name="slideDirection">
-    <v-card v-if="model" class="side-bar-card" :style="horizontalPosition">
+    <v-card v-if="model" class="side-bar-card">
       <v-card-title class="d-flex align-center justify-space-between my-1">
         <transition name="content-fade" mode="out-in">
           <div
@@ -33,7 +24,6 @@ const slideDirection = computed(() => `sidebar-slide-${props.position}`)
             <span class="font-weight-bold">{{ props.title }}</span>
           </div>
         </transition>
-
         <v-btn
           icon="mdi-close"
           variant="text"
@@ -44,20 +34,18 @@ const slideDirection = computed(() => `sidebar-slide-${props.position}`)
       </v-card-title>
       <v-card-text>
         <transition name="content-fade" mode="out-in">
-          <div :key="props.title">
-            <slot></slot>
-          </div>
+          <div :key="props.title"><slot /></div>
         </transition>
       </v-card-text>
     </v-card>
   </transition>
 </template>
 
-<style lang="scss" scoped>
+<style scoped lang="scss">
 .side-bar-card {
-  position: absolute;
-  top: calc(60px + 20px);
-  z-index: 1001;
+  width: 100%;
+  max-height: calc(100vh - 120px);
+  overflow: auto;
   background-color: rgba(255, 255, 255, 0.85);
   border: 1px solid rgba(100, 100, 100, 0.3);
   border-radius: 16px;
@@ -79,6 +67,7 @@ const slideDirection = computed(() => `sidebar-slide-${props.position}`)
   opacity: 0;
   transform: translateX(-30px);
 }
+
 .sidebar-slide-left-enter-to,
 .sidebar-slide-left-leave-from {
   opacity: 1;
@@ -90,6 +79,7 @@ const slideDirection = computed(() => `sidebar-slide-${props.position}`)
   opacity: 0;
   transform: translateX(30px);
 }
+
 .sidebar-slide-right-enter-to,
 .sidebar-slide-right-leave-from {
   opacity: 1;
@@ -100,14 +90,46 @@ const slideDirection = computed(() => `sidebar-slide-${props.position}`)
 .content-fade-leave-active {
   transition: opacity 0.25s ease;
 }
-
 .content-fade-enter-from,
 .content-fade-leave-to {
   opacity: 0;
 }
-
 .content-fade-enter-to,
 .content-fade-leave-from {
   opacity: 1;
+}
+</style>
+
+<style lang="scss">
+.section {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.4rem;
+
+  &.arrivals {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+.label,
+.value {
+  font-size: clamp(0.8rem, 0.75rem + 0.2vw, 1rem);
+  color: #111;
+}
+
+.label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+.value {
+  font-weight: 450;
+  text-align: right;
 }
 </style>

--- a/frontend/src/components/sidebar/StopSidebarComponent.vue
+++ b/frontend/src/components/sidebar/StopSidebarComponent.vue
@@ -28,6 +28,13 @@ const props = defineProps<{
 const routes = ref<city.RouteInfo[]>([])
 const arrivalsInfo = ref<simulation.Arrival[]>([])
 const routeChipColumns = ref(5)
+const tab = ref<"arr" | "occ">("arr")
+
+const emit = defineEmits(["routeSelected"])
+
+function onChipClick(route: city.RouteInfo) {
+  emit("routeSelected", route)
+}
 
 watch(
   () => props.stop?.id,
@@ -104,6 +111,7 @@ watch(
               color: route.text_color,
               backgroundColor: route.background_color,
             }"
+            @click="onChipClick(route)"
           >
             {{ route.name }}
           </span>
@@ -112,68 +120,56 @@ watch(
         <span v-else>No routes</span>
       </div>
     </div>
+    <div class="section">
+      <div class="label">
+        <v-icon icon="mdi-bus-stop-covered" class="mr-2"></v-icon>
+        Passengers at stop
+      </div>
 
-    <v-data-table
-      v-if="arrivalsInfo.length"
-      :headers="headers"
-      :header-props="{
-        style: 'font-weight: bold;',
-      }"
-      :items="arrivalsInfo"
-      class="arrivals-table"
-      density="compact"
-      hide-default-footer
-      hover
-    >
-      <template v-slot:top>
-        <div class="label">
-          <v-icon icon="mdi-clock-time-four" class="mr-2"></v-icon>
-          Arrivals
-        </div>
-      </template>
+      <div class="value">
+        <span> TODO </span>
+      </div>
+    </div>
 
-      <template v-slot:item.time="{ item }">
-        <span v-if="item.time === 0" class="blinking"> &gt;&gt;&gt; </span>
+    <v-tabs v-model="tab" grow>
+      <v-tab value="arr">Arrivals</v-tab>
+      <v-tab value="occ">Occupancy graph</v-tab>
+    </v-tabs>
 
-        <span v-else>{{ item.time }} min</span>
-      </template>
-    </v-data-table>
+    <v-card-text>
+      <v-tabs-window v-model="tab">
+        <v-tabs-window-item value="arr">
+          <v-data-table
+            v-if="arrivalsInfo.length && tab === 'arr'"
+            :headers="headers"
+            :header-props="{
+              style: 'font-weight: bold;',
+            }"
+            :items="arrivalsInfo"
+            class="stops-table"
+            density="compact"
+            hide-default-footer
+            hover
+          >
+            <template v-slot:item.time="{ item }">
+              <span v-if="item.time === 0" class="blinking">
+                &gt;&gt;&gt;
+              </span>
+
+              <span v-else>{{ item.time }} min</span>
+            </template>
+          </v-data-table>
+        </v-tabs-window-item>
+
+        <v-tabs-window-item value="occ">
+          Occupancy graph TODO
+        </v-tabs-window-item>
+      </v-tabs-window>
+    </v-card-text>
   </SidebarComponent>
 </template>
 
 <style scoped lang="scss">
-.section {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 0.4rem;
-
-  &.arrivals {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-.label,
-.value {
-  font-size: clamp(0.8rem, 0.75rem + 0.2vw, 1rem);
-  color: #111;
-}
-
-.label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-weight: bold;
-  margin-bottom: 0.25rem;
-}
-
-.value {
-  font-weight: 450;
-  text-align: right;
-}
-
 .route-chips {
   display: grid;
   gap: 4px;
@@ -201,11 +197,6 @@ watch(
   }
 }
 
-.arrivals-table {
-  width: 100%;
-  background-color: transparent;
-}
-
 .blinking {
   animation: smooth-blink 1s ease-in-out infinite;
 }
@@ -218,5 +209,10 @@ watch(
   50% {
     opacity: 0;
   }
+}
+
+.stops-table {
+  width: 100%;
+  background-color: transparent;
 }
 </style>

--- a/frontend/src/components/sidebar/TramSidebarComponent.vue
+++ b/frontend/src/components/sidebar/TramSidebarComponent.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
 }>()
 
 const tramDetails = ref<simulation.TramDetails>()
+const tab = ref<"stops" | "occ" | "delay">("stops")
 
 const headers = [
   { title: "Stop name", key: "stop", align: "center", sortable: false },
@@ -121,44 +122,63 @@ watch(
         Stops
       </div>
     </div>
+    <v-tabs v-model="tab" grow>
+      <v-tab value="stops">Stops table</v-tab>
+      <v-tab value="occ">Occupancy graph</v-tab>
+      <v-tab value="delay">Delay graph</v-tab>
+    </v-tabs>
 
-    <div class="scrollable">
-      <v-data-table-virtual
-        v-if="tramDetails?.stop_names.length"
-        :headers="headers"
-        :header-props="{
-          style: 'font-weight: bold;',
-        }"
-        :items="stopsTableData"
-        :row-props="getRowProps"
-        class="stops-table"
-        density="compact"
-        hide-default-footer
-        hover
-      >
-        <template v-slot:item.time="{ item }">
-          {{ new Time(item.time).toShortMinuteString() }}
-        </template>
+    <v-card-text>
+      <v-tabs-window v-model="tab">
+        <v-tabs-window-item value="stops">
+          <div class="scrollable">
+            <v-data-table-virtual
+              v-if="tramDetails?.stop_names.length"
+              :headers="headers"
+              :header-props="{
+                style: 'font-weight: bold;',
+              }"
+              :items="stopsTableData"
+              :row-props="getRowProps"
+              class="stops-table"
+              density="compact"
+              hide-default-footer
+              hover
+            >
+              <template v-slot:item.time="{ item }">
+                {{ new Time(item.time).toShortMinuteString() }}
+              </template>
 
-        <template v-slot:item.arrival="{ item }">
-          <span
-            v-if="item.arrival != null"
-            :class="getDelayTextColorClass(item.arrival)"
-          >
-            {{ new Time(item.arrival, true).toShortSecondString() }}
-          </span>
-        </template>
+              <template v-slot:item.arrival="{ item }">
+                <span
+                  v-if="item.arrival != null"
+                  :class="getDelayTextColorClass(item.arrival)"
+                >
+                  {{ new Time(item.arrival, true).toShortSecondString() }}
+                </span>
+              </template>
 
-        <template v-slot:item.departure="{ item }">
-          <span
-            v-if="item.departure != null"
-            :class="getDelayTextColorClass(item.departure)"
-          >
-            {{ new Time(item.departure, true).toShortSecondString() }}
-          </span>
-        </template>
-      </v-data-table-virtual>
-    </div>
+              <template v-slot:item.departure="{ item }">
+                <span
+                  v-if="item.departure != null"
+                  :class="getDelayTextColorClass(item.departure)"
+                >
+                  {{ new Time(item.departure, true).toShortSecondString() }}
+                </span>
+              </template>
+            </v-data-table-virtual>
+          </div>
+        </v-tabs-window-item>
+
+        <v-tabs-window-item value="occ">
+          Occupancy graph TODO
+        </v-tabs-window-item>
+
+        <v-tabs-window-item value="delay">
+          Delay graph TODO
+        </v-tabs-window-item>
+      </v-tabs-window>
+    </v-card-text>
   </SidebarComponent>
 </template>
 
@@ -175,28 +195,6 @@ watch(
 .scrollable::-webkit-scrollbar-thumb {
   background-color: rgba(0, 0, 0, 0.2);
   border-radius: 3px;
-}
-
-.section {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 0.4rem;
-}
-
-.label,
-.value {
-  font-size: clamp(0.8rem, 0.75rem + 0.2vw, 1rem);
-  color: #111;
-}
-
-.label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-weight: bold;
-  margin-bottom: 0.25rem;
 }
 
 .stops-table {

--- a/pkg/controlcenter/control_center.go
+++ b/pkg/controlcenter/control_center.go
@@ -1,8 +1,9 @@
 package controlcenter
 
 import (
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/TNSEngineerEdition/WailsClient/pkg/city"
 )
@@ -125,11 +126,11 @@ func (c *ControlCenter) GetRoutePolylines(lineName string) RoutePolylines {
 	for _, v := range agg {
 		list = append(list, v)
 	}
-	sort.Slice(list, func(i, j int) bool {
-		if list[i].count == list[j].count {
-			return len(list[i].bestTrip.Stops) > len(list[j].bestTrip.Stops)
+	slices.SortFunc(list, func(a, b *dirAgg) int {
+		if a.count == b.count {
+			return -cmp.Compare(len(a.bestTrip.Stops), len(b.bestTrip.Stops))
 		}
-		return list[i].count > list[j].count
+		return -cmp.Compare(a.count, b.count)
 	})
 
 	outA := stopsToIDs(list[0].bestTrip.Stops)

--- a/pkg/controlcenter/control_center.go
+++ b/pkg/controlcenter/control_center.go
@@ -2,6 +2,7 @@ package controlcenter
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/TNSEngineerEdition/WailsClient/pkg/city"
 )
@@ -15,12 +16,16 @@ type ControlCenter struct {
 	paths map[stopPair]Path
 }
 
+type RoutePolylines struct {
+	Forward  [][2]float32 `json:"forward"`
+	Backward [][2]float32 `json:"backward"`
+}
+
 func NewControlCenter(cityPointer *city.City) ControlCenter {
 	c := ControlCenter{
 		city:  cityPointer,
 		paths: make(map[stopPair]Path),
 	}
-
 	for _, route := range cityPointer.GetTramRoutes() {
 		for _, trip := range route.Trips {
 			for i := 0; i < len(trip.Stops)-1; i++ {
@@ -45,4 +50,99 @@ func (c *ControlCenter) GetPath(sourceNodeID, destinationNodeID uint64) *Path {
 	}
 
 	panic(fmt.Sprintf("No path found between %d and %d nodes", sourceNodeID, destinationNodeID))
+}
+
+// TODO: Temporary implementation of GetRoutePolylines and helper functions.
+//
+//	This part will be simplified after the TramRoute data structure is updated.
+func (c *ControlCenter) coordsFromStopSequence(stopIDs []uint64) [][2]float32 {
+	if len(stopIDs) < 2 {
+		return nil
+	}
+
+	var out [][2]float32
+
+	for i := 0; i+1 < len(stopIDs); i++ {
+		key := stopPair{source: stopIDs[i], destination: stopIDs[i+1]}
+		p := c.paths[key]
+		pts := coordsFromPathNodes(&p)
+
+		if len(out) > 0 && len(pts) > 0 && out[len(out)-1] == pts[0] {
+			out = append(out, pts[1:]...)
+		} else {
+			out = append(out, pts...)
+		}
+	}
+
+	return out
+}
+
+func coordsFromPathNodes(p *Path) [][2]float32 {
+	out := make([][2]float32, 0, len(p.Nodes))
+	for _, n := range p.Nodes {
+		out = append(out, [2]float32{float32(n.Latitude), float32(n.Longitude)})
+	}
+	return out
+}
+
+func (c *ControlCenter) GetRoutePolylines(lineName string) RoutePolylines {
+	routes := c.city.GetTramRoutes()
+
+	var route *city.TramRoute
+	for i := range routes {
+		if routes[i].Name == lineName {
+			r := routes[i]
+			route = &r
+			break
+		}
+	}
+
+	type dirKey struct{ start, end uint64 }
+	type dirAgg struct {
+		key      dirKey
+		count    int
+		bestTrip city.TramTrip
+	}
+
+	agg := make(map[dirKey]*dirAgg)
+	for _, trip := range route.Trips {
+		key := dirKey{
+			start: trip.Stops[0].ID,
+			end:   trip.Stops[len(trip.Stops)-1].ID,
+		}
+		entry := agg[key]
+		if entry == nil {
+			entry = &dirAgg{key: key}
+			agg[key] = entry
+		}
+		entry.count++
+		if len(trip.Stops) > len(entry.bestTrip.Stops) {
+			entry.bestTrip = trip
+		}
+	}
+
+	list := make([]*dirAgg, 0, len(agg))
+	for _, v := range agg {
+		list = append(list, v)
+	}
+	sort.Slice(list, func(i, j int) bool {
+		if list[i].count == list[j].count {
+			return len(list[i].bestTrip.Stops) > len(list[j].bestTrip.Stops)
+		}
+		return list[i].count > list[j].count
+	})
+
+	outA := stopsToIDs(list[0].bestTrip.Stops)
+	outB := stopsToIDs(list[1].bestTrip.Stops)
+	coordsA := c.coordsFromStopSequence(outA)
+	coordsB := c.coordsFromStopSequence(outB)
+	return RoutePolylines{Forward: coordsA, Backward: coordsB}
+}
+
+func stopsToIDs(stops []city.TramTripStop) []uint64 {
+	ids := make([]uint64, len(stops))
+	for i := range stops {
+		ids[i] = stops[i].ID
+	}
+	return ids
 }

--- a/pkg/simulation/simulation.go
+++ b/pkg/simulation/simulation.go
@@ -157,3 +157,7 @@ func (s *Simulation) GetArrivalsForStop(stopID uint64, count int) []Arrival {
 
 	return arrivals[:min(len(arrivals), count)]
 }
+
+func (s *Simulation) GetRoutePolylines(lineName string) controlcenter.RoutePolylines {
+	return s.controlCenter.GetRoutePolylines(lineName)
+}


### PR DESCRIPTION
### Related issues
- #17 

### Short description
Refactored sidebar components and added a new sidebar for routes.  
The route sidebar is displayed after selecting a line chip in the stop sidebar.  

Selecting a route also updates the color and size of tram markers (the selected tram is also displayed slightly larger).  

On the backend, polylines for a route are temporarily calculated (the calculation method will change once the server response is updated).The frontend displays and animates the most common trip for the selected route.