### PR TITLE
fix: Fixed concurrent map iteration and write panic

### DIFF
--- a/frontend/src/components/simulation/header/HeaderComponent.vue
+++ b/frontend/src/components/simulation/header/HeaderComponent.vue
@@ -6,11 +6,14 @@ import { ResetSimulation } from "@wails/go/simulation/Simulation"
 import HeaderRestartConfirmationDialogComponent from "@components/simulation/header/HeaderRestartConfirmationDialogComponent.vue"
 import useTimer from "@composables/useTimer"
 import { ExportToFile } from "@wails/go/simulation/Simulation"
+import { useRouter } from "vue-router"
 
 const props = defineProps<{
   time: number
   loading: boolean
 }>()
+
+const router = useRouter()
 
 const isRunning = defineModel<boolean>("is-running", { required: true })
 const speed = defineModel<number>("speed", { required: true })
@@ -47,6 +50,12 @@ async function exportData() {
   if (error) {
     console.error(error)
   }
+}
+
+async function menu() {
+  stop()
+  await reset()
+  router.push("/")
 }
 </script>
 
@@ -105,7 +114,7 @@ async function exportData() {
             text="Menu"
             class="mx-1"
             prepend-icon="mdi-backburger"
-            to="/"
+            @click="menu"
           ></v-btn>
         </div>
       </v-col>

--- a/pkg/simulation/worker_data.go
+++ b/pkg/simulation/worker_data.go
@@ -8,12 +8,16 @@ type workerData[I any, O any] struct {
 	wg            sync.WaitGroup
 }
 
-func (w *workerData[I, O]) reset(bufferSize int) {
-	if w.inputChannel != nil {
-		close(w.inputChannel)
-	}
+func newWorkerData[I any, O any](bufferSize int) *workerData[I, O] {
+	data := workerData[I, O]{}
 
-	w.inputChannel = make(chan I, bufferSize)
-	w.outputChannel = make(chan O, bufferSize)
-	w.wg = sync.WaitGroup{}
+	data.inputChannel = make(chan I, bufferSize)
+	data.outputChannel = make(chan O, bufferSize)
+	data.wg = sync.WaitGroup{}
+
+	return &data
+}
+
+func (w *workerData[I, O]) stop() {
+	close(w.inputChannel)
 }


### PR DESCRIPTION
### Related issues
- https://github.com/TNSEngineerEdition/WailsClient/issues/53

### Short description
Fixed error mentioned in the issue by stopping the simulation before moving to main menu view, filling out `s.trams` by using a separate map, and detaching tram workers from simulation worker data.